### PR TITLE
Stragiht 오타 STRIGHT로 고침.

### DIFF
--- a/src/main/java/kr/ac/cnu/games/poker/Extractor.java
+++ b/src/main/java/kr/ac/cnu/games/poker/Extractor.java
@@ -112,13 +112,13 @@ public class Extractor {
                 result = new Hands(HandsType.THREE_CARD,minCardList);
                 break;
             case 4:
-                result = new Hands(HandsType.STRAIGHT,minCardList);
+                result = new Hands(HandsType.STRIGHT,minCardList);
                 break;
             case 5:
-                result = new Hands(HandsType.STRAIGHT,minCardList);
+                result = new Hands(HandsType.STRIGHT,minCardList);
                 break;
             case 6:
-                result = new Hands(HandsType.STRAIGHT,minCardList);
+                result = new Hands(HandsType.STRIGHT,minCardList);
                 break;
             case 7:
                 result = new Hands(HandsType.FLUSH,minCardList);
@@ -130,7 +130,7 @@ public class Extractor {
                 result = new Hands(HandsType.FOUR_CARD,minCardList);
                 break;
             default:
-                result = new Hands(HandsType.STRAIGHT_FLUSH,minCardList);
+                result = new Hands(HandsType.STRIGHT_FLUSH,minCardList);
 
         }
         return result;


### PR DESCRIPTION
원래 규칙이 STRAIGHT라서 고쳤었다가 다른 조원과의 충돌을 막기위해 원래 설정인 STRIGHT로 고침